### PR TITLE
make read_exact_into function unsafe

### DIFF
--- a/w3b-abi/src/encode.rs
+++ b/w3b-abi/src/encode.rs
@@ -46,8 +46,8 @@ fn encode_token_into(token: &Token, out: &mut String) {
     use Token::*;
 
     match token {
-        Int(int) => hex::read_exact_into(int.as_bytes(), out),
-        Uint(uint) => hex::read_exact_into(uint.as_bytes(), out),
+        Int(int) => unsafe { hex::read_exact_into(int.as_bytes(), out) },
+        Uint(uint) => unsafe { hex::read_exact_into(uint.as_bytes(), out) },
         Bool(bool) => hex::read_left_padded_into(&[*bool as u8], 32, out),
         Address(address) => hex::read_left_padded_into(address.as_bytes(), 32, out),
 

--- a/w3b-types-core/src/hex/convert.rs
+++ b/w3b-types-core/src/hex/convert.rs
@@ -70,7 +70,7 @@ pub fn read_right_padded(bytes: &[u8], max_byte_len: usize) -> String {
 #[inline]
 pub fn read_exact(bytes: &[u8]) -> String {
     let mut hex = String::from("0x");
-    unprefixed::read_exact_into(bytes, &mut hex);
+    unsafe { unprefixed::read_exact_into(bytes, &mut hex) };
     hex
 }
 
@@ -200,7 +200,7 @@ pub mod unprefixed {
     #[inline]
     pub fn read_exact(bytes: &[u8]) -> String {
         let mut hex = String::new();
-        read_exact_into(bytes, &mut hex);
+        unsafe { read_exact_into(bytes, &mut hex) };
         hex
     }
 
@@ -218,7 +218,7 @@ pub mod unprefixed {
                 bytes = &bytes[1..];
             }
 
-            read_exact_into(bytes, hex);
+            unsafe { read_exact_into(bytes, hex) };
         } else {
             hex.push('0');
         }
@@ -228,23 +228,21 @@ pub mod unprefixed {
     pub fn read_left_padded_into(bytes: &[u8], max_byte_len: usize, hex: &mut String) {
         assert!(bytes.len() <= max_byte_len, "maximum byte length exceeded");
         pad_into(max_byte_len - bytes.len(), hex);
-        read_exact_into(bytes, hex);
+        unsafe { read_exact_into(bytes, hex) };
     }
 
     #[inline]
     pub fn read_right_padded_into(bytes: &[u8], max_byte_len: usize, hex: &mut String) {
         assert!(bytes.len() <= max_byte_len, "maximum byte length exceeded");
-        read_exact_into(bytes, hex);
+        unsafe { read_exact_into(bytes, hex) };
         pad_into(max_byte_len - bytes.len(), hex);
     }
 
     #[inline]
-    pub fn read_exact_into(bytes: &[u8], hex: &mut String) {
+    pub unsafe fn read_exact_into(bytes: &[u8], hex: &mut String) {
         for byte in bytes {
-            unsafe {
-                hex.as_mut_vec().push(HEX_CHARS[(byte >> 4) as usize]);
-                hex.as_mut_vec().push(HEX_CHARS[(byte & 0xf) as usize]);
-            }
+            hex.as_mut_vec().push(HEX_CHARS[(byte >> 4) as usize]);
+            hex.as_mut_vec().push(HEX_CHARS[(byte & 0xf) as usize]);
         }
     }
 


### PR DESCRIPTION
https://github.com/axieinfinity/w3b/blob/8573b35fd76c25ffbf1f75b4ffcbd8582fc727ff/w3b-types-core/src/hex/convert.rs#L242-L249
Hello, it is not a good choice to mark the entire function body as unsafe, which will make the caller ignore the safety requirements that the function parameters must guarantee, the developer who calls the read_exact_into  function may not notice this safety requirement.
The unsafe function called needs to ensure that the parameter must be:

- This function is unsafe because the returned &mut Vec allows writing bytes which are not valid UTF-8. If this constraint is violated, using the original String after dropping the &mut Vec may violate memory safety, as the rest of the standard library assumes that Strings are valid UTF-8.
[https://doc.rust-lang.org/std/string/struct.String.html#method.as_mut_vec](url)
Marking them unsafe also means that callers must make sure they know what they're doing.